### PR TITLE
Continue not break

### DIFF
--- a/Source/Charts/Renderers/BarChartRenderer.swift
+++ b/Source/Charts/Renderers/BarChartRenderer.swift
@@ -247,7 +247,7 @@ open class BarChartRenderer: BarLineScatterCandleBubbleRenderer
                 
                 if !viewPortHandler.isInBoundsRight(_barShadowRectBuffer.origin.x)
                 {
-                    break
+                    continue
                 }
                 
                 _barShadowRectBuffer.origin.y = viewPortHandler.contentTop
@@ -274,7 +274,7 @@ open class BarChartRenderer: BarLineScatterCandleBubbleRenderer
                 
                 if (!viewPortHandler.isInBoundsRight(barRect.origin.x))
                 {
-                    break
+                    continue
                 }
                 
                 context.setFillColor(dataSet.barShadowColor.cgColor)
@@ -300,7 +300,7 @@ open class BarChartRenderer: BarLineScatterCandleBubbleRenderer
             
             if (!viewPortHandler.isInBoundsRight(barRect.origin.x))
             {
-                break
+                continue
             }
             
             if !isSingleColor
@@ -406,7 +406,7 @@ open class BarChartRenderer: BarLineScatterCandleBubbleRenderer
                         
                         if !viewPortHandler.isInBoundsRight(x)
                         {
-                            break
+                            continue
                         }
                         
                         if !viewPortHandler.isInBoundsY(rect.origin.y)
@@ -475,7 +475,7 @@ open class BarChartRenderer: BarLineScatterCandleBubbleRenderer
                         {
                             if !viewPortHandler.isInBoundsRight(x)
                             {
-                                break
+                                continue
                             }
                             
                             if !viewPortHandler.isInBoundsY(rect.origin.y)
@@ -562,7 +562,7 @@ open class BarChartRenderer: BarLineScatterCandleBubbleRenderer
                                 
                                 if !viewPortHandler.isInBoundsRight(x)
                                 {
-                                    break
+                                    continue
                                 }
                                 
                                 if !viewPortHandler.isInBoundsY(y) || !viewPortHandler.isInBoundsLeft(x)


### PR DESCRIPTION
### Issue Link :link:
Not sure why this behavior exists but the viewport doesn't appear to be updating its contentRect as the user scrolls the bar graph leading to scenario where bars are simply not rendered because they are outside of the viewportHandler's contectRect. This is simply a workaround